### PR TITLE
chore(blueprint/src/loops): add dependency `lem:caratheodory` to proof of `lem:int_cvx`

### DIFF
--- a/blueprint/src/loops.tex
+++ b/blueprint/src/loops.tex
@@ -209,7 +209,7 @@ coordinates of $x$ with respect to the affine basis $p_0, \ldots, p_d$.
 
 \begin{proof}
   \leanok
-  \uses{lem:interior_chab,lem:int_homothety_cvx}
+  \uses{lem:caratheodory,lem:interior_chab,lem:int_homothety_cvx}
   It follows from lemma \Cref{lem:interior_chab} that we need only show that $E$
   has an affine basis $b$ of points belonging to $P$ such that $x$ lies in
   the interior of the convex hull of $b$.


### PR DESCRIPTION
Prior to https://github.com/leanprover-community/sphere-eversion/pull/29
this dependency was transitively obtained via the lemma
`lem:refined_caratheodory`. With that old lemma removed, I forgot to add
this directly.