### PR TITLE
chore(docs/blueprint/styles/dep_graph.css): add `cursor: pointer` to nodes.

### DIFF
--- a/docs/blueprint/styles/dep_graph.css
+++ b/docs/blueprint/styles/dep_graph.css
@@ -166,3 +166,7 @@ ul.tooltip_list li {
 .tooltip:hover .tooltip_list {
   visibility: visible;
 }
+
+.node {
+  cursor: pointer;
+}


### PR DESCRIPTION
A friend pointed out that he had not realised the nodes in the dependency graph were clickable and suggested this change.

Co-authored-by: Ben North <ben@redfrontdoor.org>