### PR TITLE
chore: remove LinearIsometryEquiv.apply_ne_zero

### DIFF
--- a/SphereEversion/Local/SphereEversion.lean
+++ b/SphereEversion/Local/SphereEversion.lean
@@ -177,7 +177,7 @@ theorem loc_immersion_rel_ample (n : ℕ) [Fact (dim E = n + 1)] (h : finrank �
   have hφ : InjOn φ (ℝ ∙ x)ᗮ := h_mem hx
   clear h_mem
   let u : E := (InnerProductSpace.toDual ℝ E).symm p.π
-  have u_ne : u ≠ 0 := (InnerProductSpace.toDual ℝ E).symm.apply_ne_zero p.pi_ne_zero
+  have u_ne : u ≠ 0 := EmbeddingLike.map_ne_zero_iff.mpr p.pi_ne_zero
   by_cases H : ker p.π = (ℝ ∙ x)ᗮ
   · have key : ∀ w, EqOn (p.update φ w) φ (ℝ ∙ x)ᗮ := by
       intro w x

--- a/SphereEversion/ToMathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/SphereEversion/ToMathlib/Analysis/InnerProductSpace/Projection.lean
@@ -43,12 +43,6 @@ end GeneralStuff
 
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] --[CompleteSpace E]
 
-theorem LinearIsometryEquiv.apply_ne_zero {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F] (φ : E ≃ₗᵢ⋆[ℝ] F)
-    {x : E} (hx : x ≠ 0) : φ x ≠ 0 := by
-  refine fun H ↦ hx ?_
-  rw [← φ.symm_apply_apply x, H, φ.symm.map_zero]
-
 /-- The line (one-dimensional submodule of `E`) spanned by `x : E`. -/
 @[reducible] def spanLine (x : E) : Submodule ℝ E := Submodule.span ℝ ({x} : Set E)
 


### PR DESCRIPTION
This is a weaker variant of EmbeddingLike.map_ne_zero_iff.